### PR TITLE
Take port from the environment if it is available

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -22,6 +22,7 @@
  SOFTWARE.
 */
 
+import Foundation
 import swiftra
 
 #if os(Linux)
@@ -40,4 +41,5 @@ get("/def") { req in
     return "/def was was requested with GET"
 }
 
-serve(8080)
+let port = NSProcessInfo.processInfo().environment["PORT"].flatMap { UInt16($0) }
+serve(port ?? 8080)


### PR DESCRIPTION
Allow specifying a port number under the `PORT` environment variable to override the default.

With this, along with the patches to `http4swift` and `Swiftra` that I have just opened PR's for, I have successfully been able to deploy this app to a Cloud Foundry host (specifically, [Pivotal Web Services](https://run.pivotal.io))
